### PR TITLE
concurrencyts::async and concurrencyts::future::then continuations.

### DIFF
--- a/future.cc
+++ b/future.cc
@@ -8,11 +8,12 @@ double foo(int arg, int f1) {
 
 struct Foo {
   double operator()(int arg, int f1) {
+    std::this_thread::sleep_for(std::chrono::seconds(2));
     return 3.14159259 + arg + f1;
   }
 };
 
-int main() {
+void fnp() {
   concurrencyts::promise<int> promise;
   auto f = promise.get_future();
 
@@ -23,5 +24,21 @@ int main() {
   thr.detach();
 
   f.wait();
+  std::cout << "Done waiting in fnp\n";
   std::cout << f.then(Foo{}, 20).get() << '\n';
+}
+
+void simple() {
+  auto f = concurrencyts::async([]()->double{
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    return 3.14159259;
+  });
+
+  f.wait();
+  std::cout << f.get() << '\n';
+}
+
+int main() {
+  fnp();
+  simple();
 }


### PR DESCRIPTION
concurrencyts::async (akin to std::future) implementation that returns concurrencyts::future.

Plus a more complete implementation of future continuations using then, which run on separate threads.